### PR TITLE
[DATALAB-2101]: [Azure][GCP]: Keycloak client should be created during project creation

### DIFF
--- a/infrastructure-provisioning/src/project/scripts/configure_keycloak.py
+++ b/infrastructure-provisioning/src/project/scripts/configure_keycloak.py
@@ -24,6 +24,7 @@
 import argparse
 import logging
 import requests
+import uuid
 from datalab.actions_lib import *
 from datalab.fab import *
 from datalab.meta_lib import *


### PR DESCRIPTION
added uuid import in configure keycloak