### PR TITLE
[DATALAB-2119]: JupyterLab creation fails due to 'argparse' is not defined

### DIFF
--- a/infrastructure-provisioning/src/general/scripts/os/jupyterlab_container_start.py
+++ b/infrastructure-provisioning/src/general/scripts/os/jupyterlab_container_start.py
@@ -22,6 +22,7 @@
 # ******************************************************************************
 
 import sys
+import argparse
 from datalab.fab import *
 from datalab.notebook_lib import *
 from fabric.api import *


### PR DESCRIPTION
added missing argparse import