### PR TITLE
[DATALAB-2168]: SSN deployment fails on step if downloading qtconsole

### DIFF
--- a/infrastructure-provisioning/src/general/files/gcp/base_Dockerfile
+++ b/infrastructure-provisioning/src/general/files/gcp/base_Dockerfile
@@ -30,7 +30,7 @@ RUN	apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install any python dependencies
-RUN pip install -UI pip==20.1 && \
+RUN pip install -UI qtconsole==4.7.7 pip==20.1 && \
     pip install boto3 backoff fabric==1.14.0 fabvenv  argparse ujson jupyter pycrypto google-api-python-client google-cloud-storage \
     pyyaml google-auth-httplib2 oauth2client
 


### PR DESCRIPTION
specified qtconsole version in base dockerfile