### PR TITLE
[DATALAB-2190]: Notebook creation fails on stage of 'IRkernel' installation

### DIFF
--- a/infrastructure-provisioning/src/jupyter/scripts/configure_jupyter_node.py
+++ b/infrastructure-provisioning/src/jupyter/scripts/configure_jupyter_node.py
@@ -63,7 +63,7 @@ templates_dir = '/root/templates/'
 files_dir = '/root/files/'
 local_spark_path = '/opt/spark/'
 toree_link = 'http://archive.apache.org/dist/incubator/toree/0.3.0-incubating/toree-pip/toree-0.3.0.tar.gz'
-r_libs = ['R6', 'pbdZMQ', 'RCurl', 'reshape2', 'caTools=1.17.1.4', 'rJava', 'ggplot2']
+r_libs = ['R6', 'pbdZMQ', 'RCurl', 'reshape2', 'caTools={}'.format(os.environ['notebook_catools_version']), 'rJava', 'ggplot2']
 gitlab_certfile = os.environ['conf_gitlab_certfile']
 
 


### PR DESCRIPTION
moved caTools version to datalab.ini for jupyter