### PR TITLE
[DATALAB-2333]: added policies detachment from *-ssn-role

### DIFF
--- a/infrastructure-provisioning/src/general/lib/aws/actions_lib.py
+++ b/infrastructure-provisioning/src/general/lib/aws/actions_lib.py
@@ -956,8 +956,9 @@ def remove_all_iam_resources(instance_type, project_name='', endpoint_name=''):
                         print('There is no policy {}-ssn-policy to delete'.format(service_base_name))
                     attached_role_policies = client.list_attached_role_policies(RoleName=iam_role)
                     if attached_role_policies:
-                        print('========1')
-                        print(attached_role_policies)
+                        for policy in attached_role_policies:
+                            print('========1')
+                            print(policy)
                     role_profiles = client.list_instance_profiles_for_role(RoleName=iam_role).get('InstanceProfiles')
                     if role_profiles:
                         for i in role_profiles:

--- a/infrastructure-provisioning/src/general/lib/aws/actions_lib.py
+++ b/infrastructure-provisioning/src/general/lib/aws/actions_lib.py
@@ -956,7 +956,7 @@ def remove_all_iam_resources(instance_type, project_name='', endpoint_name=''):
                         print('There is no policy {}-ssn-policy to delete'.format(service_base_name))
                     attached_role_policies = client.list_attached_role_policies(RoleName=iam_role)
                     if attached_role_policies:
-                        for policy in attached_role_policies:
+                        for policy in attached_role_policies['AttachedPolicies']:
                             print('========1')
                             print(policy)
                     role_profiles = client.list_instance_profiles_for_role(RoleName=iam_role).get('InstanceProfiles')

--- a/infrastructure-provisioning/src/general/lib/aws/actions_lib.py
+++ b/infrastructure-provisioning/src/general/lib/aws/actions_lib.py
@@ -954,6 +954,10 @@ def remove_all_iam_resources(instance_type, project_name='', endpoint_name=''):
                             service_base_name))
                     except:
                         print('There is no policy {}-ssn-policy to delete'.format(service_base_name))
+                    attached_role_policies = client.list_attached_role_policies(RoleName=iam_role)
+                    if attached_role_policies:
+                        print('========1')
+                        print(attached_role_policies)
                     role_profiles = client.list_instance_profiles_for_role(RoleName=iam_role).get('InstanceProfiles')
                     if role_profiles:
                         for i in role_profiles:

--- a/infrastructure-provisioning/src/general/lib/aws/actions_lib.py
+++ b/infrastructure-provisioning/src/general/lib/aws/actions_lib.py
@@ -957,8 +957,7 @@ def remove_all_iam_resources(instance_type, project_name='', endpoint_name=''):
                     attached_role_policies = client.list_attached_role_policies(RoleName=iam_role)
                     if attached_role_policies:
                         for policy in attached_role_policies['AttachedPolicies']:
-                            print('========1')
-                            print(policy)
+                            client.detach_role_policy(RoleName=iam_role, PolicyArn=policy['PolicyArn'])
                     role_profiles = client.list_instance_profiles_for_role(RoleName=iam_role).get('InstanceProfiles')
                     if role_profiles:
                         for i in role_profiles:

--- a/infrastructure-provisioning/src/general/lib/aws/actions_lib.py
+++ b/infrastructure-provisioning/src/general/lib/aws/actions_lib.py
@@ -957,6 +957,7 @@ def remove_all_iam_resources(instance_type, project_name='', endpoint_name=''):
                     attached_role_policies = client.list_attached_role_policies(RoleName=iam_role)
                     if attached_role_policies:
                         for policy in attached_role_policies['AttachedPolicies']:
+                            print('{} has been detached from {} role'.format(policy['PolicyName'], iam_role))
                             client.detach_role_policy(RoleName=iam_role, PolicyArn=policy['PolicyArn'])
                     role_profiles = client.list_instance_profiles_for_role(RoleName=iam_role).get('InstanceProfiles')
                     if role_profiles:


### PR DESCRIPTION
added in case if some policy that was not created during datalab deployment has been added to *-ssn-role. Otherwise ssn termination fails as it can not delete roles with attached policies