### PR TITLE
[DATALAB-2413]-changed repository for mongo-quartz dependency

### DIFF
--- a/services/self-service/pom.xml
+++ b/services/self-service/pom.xml
@@ -29,8 +29,8 @@
 
     <repositories>
         <repository>
-            <id>michaelklishin</id>
-            <url>https://dl.bintray.com/michaelklishin/maven/</url>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 
@@ -51,7 +51,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.novemberain</groupId>
+            <groupId>com.github.michaelklishin</groupId>
             <artifactId>quartz-mongodb</artifactId>
             <version>2.1.0</version>
         </dependency>


### PR DESCRIPTION
when I try to run command `mvn clean install -DskipTests -U` the Bintray repositories returning `Forbidden` response and there is information in Bintray the repositories will be sunset. when I try to run with maven central returning response
```
[ERROR] Failed to execute goal on project self-service: Could not resolve dependencies for project com.epam.datalab:self-service:jar:1.0: Could not find artifact com.novemberain:quartz-mongodb:jar:2.1.0 in central (https://repo.maven.apache.org/maven2) -> [Help 1]
```

So I change the repositories to Jitpack based on discussion on Github 
https://github.com/michaelklishin/quartz-mongodb/issues/217#issuecomment-861451719
