### PR TITLE
[DATALAB-1838]: fixed Notebook/compute creation/starting fails

### DIFF
--- a/infrastructure-provisioning/src/general/scripts/os/update_inactivity_on_start.py
+++ b/infrastructure-provisioning/src/general/scripts/os/update_inactivity_on_start.py
@@ -44,6 +44,8 @@ if __name__ == "__main__":
     else:
         kernel = args.cluster_ip.replace('.', '-')
 
+    if os.environ['conf_cloud_provider'] == 'azure':
+        datalab.actions_lib.ensure_right_mount_paths()
     conn.sudo('''bash -c -l "date +%s > /opt/inactivity/{}_inactivity" '''.format(kernel))
 
     conn.close()


### PR DESCRIPTION
added check if disks are mounted right during notebook start on azure