### PR TITLE
[DATALAB-2553]: fixed Spark creation fails on stage of configuration

### DIFF
--- a/infrastructure-provisioning/src/general/lib/os/logger.py
+++ b/infrastructure-provisioning/src/general/lib/os/logger.py
@@ -21,6 +21,13 @@
 
 import logging
 import os
+import subprocess
+
+#quick fix for spark configuration, when python script is launched on notebook instance without environment variables and log directories
+if 'conf_resource' not in os.environ and 'request_id' not in os.environ:
+    os.environ['conf_resource'] = 'undefined_conf_resource'
+    os.environ['request_id'] = 'undefined_request_id'
+    subprocess.run("sudo mkdir -p /logs/undefined_conf_resource/", shell=True, check=True)
 
 local_log_filename = "{}_{}.log".format(os.environ['conf_resource'], os.environ['request_id'])
 local_log_filepath = "/logs/" + os.environ['conf_resource'] + "/" + local_log_filename


### PR DESCRIPTION
added quickfix for logger when used not in docker containers but directly on instances