### PR TITLE
[DATALAB-2813]: AWS Deeplearning Image Update

### DIFF
--- a/infrastructure-provisioning/src/general/conf/datalab.ini
+++ b/infrastructure-provisioning/src/general/conf/datalab.ini
@@ -361,13 +361,13 @@ superset_version = 0.35.1
 ### GCS-connector version
 gcs_connector_version = 2.0.1
 ### Setuptools version
-setuptools_version = 54.1.1
+setuptools_version = 59.6.0
 ### Roxygen2 version
 roxygen2_version = 7.1.1
 ### Nbconvert version
 nbconvert_version = 5.6.1
 ### nbformat_version
-nbformat_version = 5.3.0
+nbformat_version = 5.1.3
 ### jupyterlab version
 jupyterlab_version = 3.2.9
 

--- a/infrastructure-provisioning/src/general/files/aws/deeplearning_description.json
+++ b/infrastructure-provisioning/src/general/files/aws/deeplearning_description.json
@@ -8,10 +8,10 @@
   "exploratory_environment_versions" :
   [
     {
-      "template_name": "Deep Learning AMI Version 42.1",
-      "description": "MXNet-1.8.0 & 1.7.0, TensorFlow-2.4.1, 2.1.3 & 1.15.5, PyTorch-1.4.0 & 1.8.0, Neuron, & others. NVIDIA CUDA, cuDNN, NCCL, Intel MKL-DNN, Docker, NVIDIA-Docker & EFA support. Uses Anaconda virtual environments, configured to keep the different framework installations separate and easy to switch between frameworks as Jupyter kernels.",
+      "template_name": "Deep Learning AMI Version 60.2",
+      "description": "MXNet-1.8, TensorFlow-2.7, PyTorch-1.10, Neuron, & others. NVIDIA CUDA, cuDNN, NCCL, Intel MKL-DNN, Docker, NVIDIA-Docker & EFA support. For fully managed experience, check: https://aws.amazon.com/sagemaker",
       "environment_type": "exploratory",
-      "version": "Deep Learning AMI (Ubuntu 18.04) Version 42.1",
+      "version": "Deep Learning AMI (Ubuntu 18.04) Version 60.2",
       "vendor": "AWS"
     }
   ],

--- a/infrastructure-provisioning/src/general/lib/os/debian/notebook_lib.py
+++ b/infrastructure-provisioning/src/general/lib/os/debian/notebook_lib.py
@@ -277,7 +277,7 @@ def ensure_python3_libraries(os_user):
                 datalab.fab.conn.sudo('-i pip3 install -U keyrings.alt backoff')
                 datalab.fab.conn.sudo('-i pip3 install --upgrade --user pyqt5==5.12')
                 datalab.fab.conn.sudo('-i pip3 install --upgrade --user pyqtwebengine==5.12')
-                datalab.fab.conn.sudo('-i pip3 install setuptools')
+                datalab.fab.conn.sudo('pip3 install setuptools=={}'.format(os.environ['notebook_setuptools_version']))
                 try:
                     datalab.fab.conn.sudo(
                         '-i pip3 install tornado=={0} ipython==7.21.0 ipykernel=={1} nbconvert=={2} nbformat=={3} sparkmagic --no-cache-dir' \

--- a/infrastructure-provisioning/src/general/scripts/aws/common_prepare_notebook.py
+++ b/infrastructure-provisioning/src/general/scripts/aws/common_prepare_notebook.py
@@ -82,7 +82,7 @@ if __name__ == "__main__":
         #notebook_config['primary_disk_size'] = (lambda x: '100' if x == 'deeplearning' else '16')(
         #    os.environ['application'])
         if os.environ['application'] == 'deeplearning':
-            notebook_config['primary_disk_size'] = '100'
+            notebook_config['primary_disk_size'] = '150'
         elif os.environ['application'] == 'tensor':
             notebook_config['primary_disk_size'] = '28'
         else:

--- a/services/self-service/src/main/java/com/epam/datalab/backendapi/domain/NotebookTemplate.java
+++ b/services/self-service/src/main/java/com/epam/datalab/backendapi/domain/NotebookTemplate.java
@@ -36,7 +36,7 @@ public enum NotebookTemplate {
     RSTUDIO("RStudio 2021.09.1-372"),
     TENSOR_GCP("Jupyter with TensorFlow 2.1.0"),
     DEEP_LEARNING_GCP("Deeplearning notebook"),
-    DEEP_LEARNING_AWS("Deep Learning AMI Version 42.1"),
+    DEEP_LEARNING_AWS("Deep Learning AMI Version 60.2"),
     DEEP_LEARNING_AZURE("Data Science Virtual Machine - Ubuntu 18.04");
 
 

--- a/services/self-service/src/main/java/com/epam/datalab/backendapi/service/impl/ExploratoryServiceImpl.java
+++ b/services/self-service/src/main/java/com/epam/datalab/backendapi/service/impl/ExploratoryServiceImpl.java
@@ -151,7 +151,7 @@ public class ExploratoryServiceImpl implements ExploratoryService {
     }
 
     private boolean isDeepLearningOnAwsOrAzure(Exploratory exploratory, EndpointDTO endpointDTO) {
-        return exploratory.getVersion().equals("Deep Learning AMI (Ubuntu 18.04) Version 42.1") ||
+        return exploratory.getVersion().equals("Deep Learning AMI (Ubuntu 18.04) Version 60.2") ||
                 exploratory.getVersion().equals("microsoft-dsvm:ubuntu-1804:1804");
     }
 


### PR DESCRIPTION
- aws deeplearning image version update
- primary ebs size raised to 150gb
- setuptools updated to 59.6.0
- nbformat downgraded to 5.1.3