### PR TITLE
[DATALAB-2819]: removed converting words to lowercase in azure/jupyterlab

### DIFF
--- a/infrastructure-provisioning/src/general/scripts/azure/jupyterlab_configure.py
+++ b/infrastructure-provisioning/src/general/scripts/azure/jupyterlab_configure.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
         AzureActions = datalab.actions_lib.AzureActions()
         notebook_config = dict()
         try:
-            notebook_config['exploratory_name'] = (os.environ['exploratory_name']).replace('_', '-').lower()
+            notebook_config['exploratory_name'] = (os.environ['exploratory_name']).replace('_', '-')
         except:
             notebook_config['exploratory_name'] = ''
         notebook_config['service_base_name'] = os.environ['conf_service_base_name']


### PR DESCRIPTION
Fixed problem with stopping jupyterlab playbooks which contains uppercase in own name