### PR TITLE
[DATALAB-2758]: Replaced hardcoded configuration for realm

### DIFF
--- a/infrastructure-provisioning/terraform/bin/deploy/endpoint_fab.py
+++ b/infrastructure-provisioning/terraform/bin/deploy/endpoint_fab.py
@@ -756,6 +756,10 @@ def configure_billing_endpoint(endpoint_keystore_password):
                     {
                         'key': "KEYCLOAK_AUTH_SERVER_URL",
                         'value': args.keycloak_auth_server_url
+                    },
+                    {
+                        'key': "KEYCLOAK_REALM_NAME",
+                        'value': args.keycloak_realm_name
                     }
                 ]
                 for param in billing_app_properties:
@@ -882,6 +886,10 @@ def configure_billing_endpoint(endpoint_keystore_password):
                     {
                         'key': "KEYCLOAK_AUTH_SERVER_URL",
                         'value': args.keycloak_auth_server_url
+                    },
+                    {
+                        'key': "KEYCLOAK_REALM_NAME",
+                        'value': args.keycloak_realm_name
                     }
                 ]
             elif args.cloud_provider == 'azure':
@@ -921,6 +929,10 @@ def configure_billing_endpoint(endpoint_keystore_password):
                     {
                         'key': "KEYCLOAK_AUTH_SERVER_URL",
                         'value': args.keycloak_auth_server_url
+                    },
+                    {
+                        'key': "KEYCLOAK_REALM_NAME",
+                        'value': args.keycloak_realm_name
                     },
                     {
                         'key': "CLIENT_ID",

--- a/services/billing-aws/src/main/resources/application.yml
+++ b/services/billing-aws/src/main/resources/application.yml
@@ -48,7 +48,7 @@ logging:
 
 keycloak:
   bearer-only: true
-  realm: datalab
+  realm: KEYCLOAK_REALM_NAME
   resource: KEYCLOAK_CLIENT_ID
   credentials.secret: KEYCLOAK_CLIENT_SECRET
   ssl-required: none

--- a/services/billing-azure/src/main/resources/application.yml
+++ b/services/billing-azure/src/main/resources/application.yml
@@ -48,7 +48,7 @@ logging:
 
 keycloak:
   bearer-only: true
-  realm: datalab
+  realm: KEYCLOAK_REALM_NAME
   resource: KEYCLOAK_CLIENT_ID
   credentials.secret: CLIENT_SECRET
   ssl-required: none

--- a/services/billing-gcp/src/main/resources/application.yml
+++ b/services/billing-gcp/src/main/resources/application.yml
@@ -52,7 +52,7 @@ logging:
 
 keycloak:
   bearer-only: true
-  realm: datalab
+  realm: KEYCLOAK_REALM_NAME
   resource: KEYCLOAK_CLIENT_ID
   credentials.secret: CLIENT_SECRET
   ssl-required: none


### PR DESCRIPTION
Replaced configuration for realm for the AWS, Azure, and GCP clouds.